### PR TITLE
Warn players if a world was not created with the mod loaded

### DIFF
--- a/src/main/java/io/github/mjtb49/strongholdtrainer/mixin/MixinEntry.java
+++ b/src/main/java/io/github/mjtb49/strongholdtrainer/mixin/MixinEntry.java
@@ -1,0 +1,62 @@
+package io.github.mjtb49.strongholdtrainer.mixin;
+
+import com.mojang.blaze3d.systems.RenderSystem;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.DrawableHelper;
+import net.minecraft.client.gui.screen.world.SelectWorldScreen;
+import net.minecraft.client.gui.screen.world.WorldListWidget;
+import net.minecraft.client.texture.NativeImageBackedTexture;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.text.LiteralText;
+import net.minecraft.text.StringRenderable;
+import net.minecraft.util.Formatting;
+import net.minecraft.util.Identifier;
+import net.minecraft.world.level.storage.LevelSummary;
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(WorldListWidget.Entry.class)
+public class MixinEntry {
+    @Shadow @Final private MinecraftClient client;
+
+    @Shadow @Final private LevelSummary level;
+
+    @Shadow @Final private SelectWorldScreen screen;
+
+    @Shadow @Final @Nullable private NativeImageBackedTexture icon;
+
+    @Shadow @Final private Identifier iconLocation;
+
+    private final static Identifier UNKNOWN = new Identifier("textures/misc/unknown_server.png");
+
+    private final static Identifier WORLD_SELECTION_ICONS =  new Identifier("textures/gui/world_selection.png");
+
+
+    @Inject(at=@At("TAIL"), method = "render(Lnet/minecraft/client/util/math/MatrixStack;IIIIIIIZF)V")
+    public void render(MatrixStack matrices, int index, int y, int x, int entryWidth, int entryHeight, int mouseX, int mouseY, boolean hovered, float tickDelta, CallbackInfo ci){
+        if(hovered || this.client.options.touchscreen){
+            if(!this.level.getFile().toPath().getParent().resolve("strongholds/").toFile().exists()){
+                // re-render world icon
+                this.client.getTextureManager().bindTexture(this.icon != null ? this.iconLocation : UNKNOWN);
+                RenderSystem.enableBlend();
+                DrawableHelper.drawTexture(matrices, x, y, 0.0F, 0.0F, 32, 32, 32, 32);
+                RenderSystem.disableBlend();
+                this.client.getTextureManager().bindTexture(WORLD_SELECTION_ICONS);
+                // Offset play icon
+                DrawableHelper.drawTexture(matrices, x, y, 32.0F, hovered ? 32 : 0, 32, 32, 256, 256);
+                // Red exclamation
+                DrawableHelper.drawTexture(matrices, x, y, 96.0f, hovered ? 32: 0, 32, 32, 256, 256);
+                if (hovered) {
+                    StringRenderable stringRenderable = (new LiteralText("This world was not created with StrongholdTrainer. Open at your own risk!")).formatted(Formatting.RED, Formatting.BOLD);
+                    this.screen.setTooltip(this.client.textRenderer.wrapLines(stringRenderable, 175));
+                }
+            }
+        }
+    }
+
+}

--- a/src/main/resources/stronghold-trainer.mixins.json
+++ b/src/main/resources/stronghold-trainer.mixins.json
@@ -20,6 +20,7 @@
     "MixinStrongholdGeneratorSquareRoom",
     "MixinStrongholdGeneratorStart",
     "MixinStrongholdPiece",
+    "MixinEntry",
     "WorldSavePathAccessor"
   ],
   "client": [


### PR DESCRIPTION
Currently, it considers valid worlds as ones with a strongholds directory. Adds a warning like the snapshot or locked warnings on the world selection screen.
![warning (2)](https://user-images.githubusercontent.com/40721769/122293022-998d0580-cec4-11eb-8eef-0a7e26c0a802.PNG)
