### PR TITLE
Collect statistics for every door-to-door pair separately

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,8 +31,8 @@ dependencies {
     mappings "net.fabricmc:yarn:1.16.1+build.21:v2"
     modImplementation "net.fabricmc:fabric-loader:0.11.3"
 
-    implementation group: 'org.tensorflow', name: 'tensorflow-core-api', version: '0.3.1'
-    implementation group: 'org.tensorflow', name: 'tensorflow-core-platform', version: '0.3.1'
+    compile group: 'org.tensorflow', name: 'tensorflow-core-api', version: '0.3.1'
+    compile group: 'org.tensorflow', name: 'tensorflow-core-platform', version: '0.3.1'
 
     modRuntime ("com.github.SuperCoder7979:databreaker:0.2.5") {
         exclude module: "fabric-loader"
@@ -75,7 +75,7 @@ task sourcesJar(type: Jar, dependsOn: classes) {
 // Configures shadowJar to use compile dependencies. Edits remapJar to use the shadow jar as its input
 shadowJar {
     classifier "shadow"
-    //configurations = [project.configurations.compile]
+    configurations = [project.configurations.compile]
     remapJar {
         dependsOn shadowJar
         input.set shadowJar.archiveFile.get()

--- a/build.gradle
+++ b/build.gradle
@@ -31,8 +31,8 @@ dependencies {
     mappings "net.fabricmc:yarn:1.16.1+build.21:v2"
     modImplementation "net.fabricmc:fabric-loader:0.11.3"
 
-    compile group: 'org.tensorflow', name: 'tensorflow-core-api', version: '0.3.1'
-    compile group: 'org.tensorflow', name: 'tensorflow-core-platform', version: '0.3.1'
+    implementation group: 'org.tensorflow', name: 'tensorflow-core-api', version: '0.3.1'
+    implementation group: 'org.tensorflow', name: 'tensorflow-core-platform', version: '0.3.1'
 
     modRuntime ("com.github.SuperCoder7979:databreaker:0.2.5") {
         exclude module: "fabric-loader"
@@ -75,7 +75,7 @@ task sourcesJar(type: Jar, dependsOn: classes) {
 // Configures shadowJar to use compile dependencies. Edits remapJar to use the shadow jar as its input
 shadowJar {
     classifier "shadow"
-    configurations = [project.configurations.compile]
+    //configurations = [project.configurations.compile]
     remapJar {
         dependsOn shadowJar
         input.set shadowJar.archiveFile.get()

--- a/src/main/java/io/github/mjtb49/strongholdtrainer/stats/PlayerPathData.java
+++ b/src/main/java/io/github/mjtb49/strongholdtrainer/stats/PlayerPathData.java
@@ -87,7 +87,7 @@ public class PlayerPathData {
     public void updateAndPrintAllStats(ServerPlayerEntity playerEntity, @Nullable String realtime, boolean invalidRun) {
         if(!invalidRun){
             StrongholdTrainerStats.updateStrongholdTimeStats(playerEntity, ticksInStronghold);
-            updateRoomStats();
+            RoomStats.updateRoomStats(path);
 
             playerEntity.increaseStat(StrongholdTrainerStats.NUM_REVIEWED_ROOMS, roomsReviewed);
             playerEntity.increaseStat(StrongholdTrainerStats.NUM_BEST_ROOMS, bestMoveCount);
@@ -112,12 +112,6 @@ public class PlayerPathData {
         playerEntity.sendMessage(new LiteralText("\u2048 Mistakes " + mistakeCount).formatted(Formatting.RED), false);
         playerEntity.sendMessage(new LiteralText("\u2047 Blunders " + blunderCount).formatted(Formatting.DARK_RED), false);
         playerEntity.sendMessage(new LiteralText("\u2194 Wormholes " + wormholeCount).formatted(Formatting.DARK_PURPLE), false);
-    }
-
-    private void updateRoomStats() {
-        for (PlayerPathEntry entry : path) {
-            RoomStats.updateRoomStats(entry.piece.getClass(), entry.ticks, entry.entrance, entry.exit);
-        }
     }
 
     private int computeMedianTimeTaken() {

--- a/src/main/java/io/github/mjtb49/strongholdtrainer/stats/PlayerPathData.java
+++ b/src/main/java/io/github/mjtb49/strongholdtrainer/stats/PlayerPathData.java
@@ -8,11 +8,9 @@ import io.github.mjtb49.strongholdtrainer.util.RoomFormatter;
 import io.github.mjtb49.strongholdtrainer.util.TimerHelper;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.stat.Stats;
-import net.minecraft.structure.StrongholdGenerator;
 import net.minecraft.text.HoverEvent;
 import net.minecraft.text.LiteralText;
 import net.minecraft.util.Formatting;
-import net.minecraft.util.Pair;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.*;
@@ -28,7 +26,7 @@ public class PlayerPathData {
     private static Path STATS_PATH;
 
     private static final DecimalFormat DF = new DecimalFormat("0.00");
-    private final ArrayList<Pair<StrongholdGenerator.Piece, Integer>> rooms;
+    private final ArrayList<PlayerPathEntry> path;
     @Expose
     private final HashMap<String, ArrayList<Integer>> roomsToWriteToFile;
     @Expose
@@ -53,7 +51,7 @@ public class PlayerPathData {
     private final int ticksLostAgainstFeinberg;
 
 
-    public PlayerPathData(ArrayList<Pair<StrongholdGenerator.Piece, Integer>> rooms,
+    public PlayerPathData(ArrayList<PlayerPathEntry> rooms,
                           int ticksInStronghold,
                           double difficulty,
                           int wastedTime,
@@ -64,7 +62,7 @@ public class PlayerPathData {
                           int wormholeCount,
                           int roomsReviewed,
                           int tickLossAgainstFeinberg) {
-        this.rooms = rooms;
+        this.path = rooms;
         this.ticksInStronghold = ticksInStronghold;
         this.difficulty = difficulty;
         this.wastedTime = wastedTime;
@@ -77,10 +75,10 @@ public class PlayerPathData {
         this.blunderCount = blunderCount;
 
         roomsToWriteToFile = new HashMap<>();
-        for (Pair<StrongholdGenerator.Piece, Integer> pair : rooms) {
-            ArrayList<Integer> list = roomsToWriteToFile.getOrDefault(RoomFormatter.ROOM_TO_STRING.get(pair.getLeft().getClass()), new ArrayList<>());
-            list.add(pair.getRight());
-            roomsToWriteToFile.put(RoomFormatter.ROOM_TO_STRING.get(pair.getLeft().getClass()), list);
+        for (PlayerPathEntry entry : path) {
+            ArrayList<Integer> list = roomsToWriteToFile.getOrDefault(RoomFormatter.ROOM_TO_STRING.get(entry.piece.getClass()), new ArrayList<>());
+            list.add(entry.ticks);
+            roomsToWriteToFile.put(RoomFormatter.ROOM_TO_STRING.get(entry.piece.getClass()), list);
         }
 
         allPlayerPathData.add(this);
@@ -117,8 +115,8 @@ public class PlayerPathData {
     }
 
     private void updateRoomStats(ServerPlayerEntity playerEntity) {
-        for (Pair<StrongholdGenerator.Piece, Integer> room : rooms) {
-            RoomStats.updateRoomStats(playerEntity, room.getLeft().getClass(), room.getRight());
+        for (PlayerPathEntry entry : path) {
+            RoomStats.updateRoomStats(playerEntity, entry.piece.getClass(), entry.ticks, entry.entrance, entry.exit);
         }
     }
 

--- a/src/main/java/io/github/mjtb49/strongholdtrainer/stats/PlayerPathData.java
+++ b/src/main/java/io/github/mjtb49/strongholdtrainer/stats/PlayerPathData.java
@@ -87,7 +87,7 @@ public class PlayerPathData {
     public void updateAndPrintAllStats(ServerPlayerEntity playerEntity, @Nullable String realtime, boolean invalidRun) {
         if(!invalidRun){
             StrongholdTrainerStats.updateStrongholdTimeStats(playerEntity, ticksInStronghold);
-            updateRoomStats(playerEntity);
+            updateRoomStats();
 
             playerEntity.increaseStat(StrongholdTrainerStats.NUM_REVIEWED_ROOMS, roomsReviewed);
             playerEntity.increaseStat(StrongholdTrainerStats.NUM_BEST_ROOMS, bestMoveCount);
@@ -114,9 +114,9 @@ public class PlayerPathData {
         playerEntity.sendMessage(new LiteralText("\u2194 Wormholes " + wormholeCount).formatted(Formatting.DARK_PURPLE), false);
     }
 
-    private void updateRoomStats(ServerPlayerEntity playerEntity) {
+    private void updateRoomStats() {
         for (PlayerPathEntry entry : path) {
-            RoomStats.updateRoomStats(playerEntity, entry.piece.getClass(), entry.ticks, entry.entrance, entry.exit);
+            RoomStats.updateRoomStats(entry.piece.getClass(), entry.ticks, entry.entrance, entry.exit);
         }
     }
 
@@ -132,6 +132,7 @@ public class PlayerPathData {
     }
 
     public static void loadAllPriorPaths(Path path) {
+        RoomStats.init(path);
         STATS_PATH = path.resolve("stats.json");
         Gson gson = new GsonBuilder()
                 .excludeFieldsWithoutExposeAnnotation()
@@ -152,6 +153,7 @@ public class PlayerPathData {
     }
 
     public static void writeAllPaths() {
+        RoomStats.writeStatsToFile();
         Gson gson = new GsonBuilder()
                 .excludeFieldsWithoutExposeAnnotation()
                 .create();

--- a/src/main/java/io/github/mjtb49/strongholdtrainer/stats/PlayerPathEntry.java
+++ b/src/main/java/io/github/mjtb49/strongholdtrainer/stats/PlayerPathEntry.java
@@ -1,0 +1,17 @@
+package io.github.mjtb49.strongholdtrainer.stats;
+
+import net.minecraft.structure.StrongholdGenerator;
+
+public class PlayerPathEntry {
+    public StrongholdGenerator.Piece piece;
+    public int ticks;
+    public int entrance;
+    public int exit;
+
+    public PlayerPathEntry(StrongholdGenerator.Piece currentPiece, int i, int entrance2, int exit2) {
+        piece = currentPiece;
+        ticks = i;
+        entrance = entrance2;
+        exit = exit2;
+    }
+}

--- a/src/main/java/io/github/mjtb49/strongholdtrainer/stats/RoomStats.java
+++ b/src/main/java/io/github/mjtb49/strongholdtrainer/stats/RoomStats.java
@@ -1,81 +1,85 @@
 package io.github.mjtb49.strongholdtrainer.stats;
 
 import io.github.mjtb49.strongholdtrainer.util.RoomFormatter;
-import net.minecraft.server.network.ServerPlayerEntity;
-import net.minecraft.stat.StatFormatter;
-import net.minecraft.stat.Stats;
 import net.minecraft.structure.StructurePiece;
-import net.minecraft.util.Identifier;
-import net.minecraft.util.registry.Registry;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.StringJoiner;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 public class RoomStats {
-    private static final Map<Class<? extends StructurePiece>, Identifier[][]> roomCountStats = new HashMap<>();
-    private static final Map<Class<? extends StructurePiece>, Identifier[][]> roomTimeStats = new HashMap<>();
-    private static final Map<Class<? extends StructurePiece>, Identifier[][]> averageTimeStats = new HashMap<>();
+    private static final DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd_HH-mm-ss");
+
+    private static final Map<Class<? extends StructurePiece>, ArrayList<Integer>[][]> roomTimeStats = new HashMap<>();
+
+    private static Path path;
+
+    private static String pieceToString(Class<? extends StructurePiece> pieceType) {
+        return RoomFormatter.ROOM_TO_STRING.get(pieceType);
+    }
+
+    private static int pieceToNumExits(Class<? extends StructurePiece> pieceType) {
+        return RoomFormatter.ROOM_TO_NUM_EXITS.get(pieceType);
+    }
 
     private static boolean isValid(Class<? extends StructurePiece> pieceType) {
         return (!RoomFormatter.ROOM_TO_STRING.get(pieceType).equals("None"));
     }
 
-    public static void register() {
-        for (Class<? extends StructurePiece> pieceType : RoomFormatter.ROOM_TO_STRING.keySet()) {
-            if (isValid(pieceType)) {
-                int num_exits = RoomFormatter.ROOM_TO_NUM_EXITS.get(pieceType);
-
-                // +2 added for entrance and wormholes
-                Identifier[][] pieceRoomCountStats = new Identifier[num_exits+2][num_exits+2];
-                Identifier[][] pieceRoomTimeStats = new Identifier[num_exits+2][num_exits+2];
-                Identifier[][] pieceAverageCountStats = new Identifier[num_exits+2][num_exits+2];
-                
-                // +1 added for wormholes, <= used for entrance
-                for (int entrance = 0; entrance <= num_exits+1; entrance++) {
-                    for (int exit = 0; exit <= num_exits+1; exit++) {
-                        // if > num_exits, converts to "worm" for clarity
-                        String entranceString = doorToString(num_exits, entrance);
-                        String exitString = doorToString(num_exits, exit);
-
-                        String countName = "piece_" + RoomFormatter.ROOM_TO_STRING.get(pieceType).toLowerCase().replace(" ", "_") + "_" + entranceString + "_" + exitString + "_count";
-                        String timeName = "piece_" + RoomFormatter.ROOM_TO_STRING.get(pieceType).toLowerCase().replace(" ", "_") + "_" + entranceString + "_" + exitString + "_total";
-                        String avgName = "piece_" + RoomFormatter.ROOM_TO_STRING.get(pieceType).toLowerCase().replace(" ", "_") + "_" + entranceString + "_" + exitString + "_avg";
-
-                        pieceRoomCountStats[entrance][exit] = new Identifier(StrongholdTrainerStats.MODID, countName);
-                        pieceRoomTimeStats[entrance][exit] = new Identifier(StrongholdTrainerStats.MODID, timeName);
-                        pieceAverageCountStats[entrance][exit] = new Identifier(StrongholdTrainerStats.MODID, avgName);
-
-                        Registry.register(Registry.CUSTOM_STAT, countName, pieceRoomCountStats[entrance][exit]);
-                        Registry.register(Registry.CUSTOM_STAT, timeName, pieceRoomTimeStats[entrance][exit]);
-                        Registry.register(Registry.CUSTOM_STAT, avgName, pieceAverageCountStats[entrance][exit]);
-
-                        Stats.CUSTOM.getOrCreateStat(pieceRoomCountStats[entrance][exit], StatFormatter.DEFAULT);
-                        Stats.CUSTOM.getOrCreateStat(pieceRoomTimeStats[entrance][exit], StatFormatter.TIME);
-                        Stats.CUSTOM.getOrCreateStat(pieceAverageCountStats[entrance][exit], StatFormatter.TIME);
-                    }
+    @SuppressWarnings("unchecked")
+    public static void init(Path path) {
+        RoomStats.path = path; 
+        for (Class<? extends StructurePiece> pieceType: RoomFormatter.ROOM_TO_STRING.keySet()) {
+            int numExits = pieceToNumExits(pieceType);
+            // +2 
+            ArrayList<Integer>[][] data = new ArrayList[numExits+2][numExits+2];
+            for (int entrance = 0; entrance <= numExits + 1; entrance++) {
+                for (int exit = 0; exit <= numExits + 1; exit++) {
+                    data[entrance][exit] = new ArrayList<>();
                 }
-
-                roomCountStats.put(pieceType, pieceRoomCountStats);
-                roomTimeStats.put(pieceType, pieceRoomTimeStats);
-                averageTimeStats.put(pieceType, pieceAverageCountStats);
             }
+            roomTimeStats.put(pieceType, data);
         }
     }
 
-    private static String doorToString(int num_exits, int door) {
-        return door > num_exits ? "worm" : Integer.toString(door);
+    // ChatGPT wrote this function... I'm impressed
+    public static void writeStatsToFile() {
+        // Create file to write to
+        LocalDateTime timestamp = LocalDateTime.now();
+        String filename = timestamp.format(dateFormatter) + ".txt";
+        try (FileWriter writer = new FileWriter(String.valueOf(path.resolve(filename)))) {
+            // Write to file
+            for (Class<? extends StructurePiece> pieceType : roomTimeStats.keySet()) {
+                if (!isValid(pieceType)) {
+                    continue;
+                }
+                writer.write(pieceToString(pieceType) + " " + pieceToNumExits(pieceType) + "\n");
+                ArrayList<Integer>[][] stats = roomTimeStats.get(pieceType);
+                for (int i = 0; i < stats.length; i++) {
+                    for (int j = 0; j < stats[i].length; j++) {
+                        writer.write(i + " " + j + ": ");
+                        StringJoiner sj = new StringJoiner(", ");
+                        for (int time : stats[i][j]) {
+                            sj.add(Integer.toString(time));
+                        }
+                        writer.write(sj.toString() + "\n");
+                    }
+                }
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
     }
 
-    public static void updateRoomStats(ServerPlayerEntity playerEntity, Class<? extends StructurePiece> pieceType, int timeInTicks, int entrance, int exit) {
-        //because of this increment count should never be 0
+    public static void updateRoomStats(Class<? extends StructurePiece> pieceType, int timeInTicks, int entrance, int exit) {
         if (isValid(pieceType)) {
-            playerEntity.incrementStat(roomCountStats.get(pieceType)[entrance][exit]);
-            playerEntity.increaseStat(roomTimeStats.get(pieceType)[entrance][exit], timeInTicks);
-            int count = playerEntity.getStatHandler().getStat(Stats.CUSTOM.getOrCreateStat(roomCountStats.get(pieceType)[entrance][exit]));
-            int time = playerEntity.getStatHandler().getStat(Stats.CUSTOM.getOrCreateStat(roomTimeStats.get(pieceType)[entrance][exit]));
-            int avg = time / count;
-            playerEntity.resetStat(Stats.CUSTOM.getOrCreateStat(averageTimeStats.get(pieceType)[entrance][exit]));
-            playerEntity.increaseStat(averageTimeStats.get(pieceType)[entrance][exit], avg);
+            roomTimeStats.get(pieceType)[entrance][exit].add(timeInTicks);
         }
     }
 }

--- a/src/main/java/io/github/mjtb49/strongholdtrainer/stats/RoomStats.java
+++ b/src/main/java/io/github/mjtb49/strongholdtrainer/stats/RoomStats.java
@@ -18,8 +18,15 @@ public class RoomStats {
 
     private static Path path;
 
-    private static String pieceToString(Class<? extends StructurePiece> pieceType) {
-        return RoomFormatter.ROOM_TO_STRING.get(pieceType);
+    private static String pieceToString(StructurePiece piece) {
+        return RoomFormatter.ROOM_TO_STRING.get(piece.getClass());
+    }
+
+    private static String doorToString(StructurePiece piece, int door) {
+        if (door > RoomFormatter.ROOM_TO_NUM_EXITS.get(piece.getClass())) {
+            return "worm";
+        }
+        return Integer.toString(door);
     }
 
     public static void init(Path path) {
@@ -36,7 +43,7 @@ public class RoomStats {
             for (ArrayList<PlayerPathEntry> path : roomTimeStats) {
                 writer.write(path.size() + "\n");
                 for (PlayerPathEntry entry : path) {
-                    writer.write(pieceToString(entry.piece.getClass()) + " " + entry.entrance + " " + entry.exit + " " + entry.ticks + "\n");
+                    writer.write(pieceToString(entry.piece) + " " + doorToString(entry.piece, entry.entrance) + " " + doorToString(entry.piece, entry.exit) + " " + entry.ticks + "\n");
                 }
             }
             writer.flush();

--- a/src/main/java/io/github/mjtb49/strongholdtrainer/stats/RoomStats.java
+++ b/src/main/java/io/github/mjtb49/strongholdtrainer/stats/RoomStats.java
@@ -12,46 +12,70 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class RoomStats {
-    private static final Map<Class<? extends StructurePiece>, Identifier> roomCountStats = new HashMap<>();
-    private static final Map<Class<? extends StructurePiece>, Identifier> roomTimeStats = new HashMap<>();
-    private static final Map<Class<? extends StructurePiece>, Identifier> averageTimeStats = new HashMap<>();
+    private static final Map<Class<? extends StructurePiece>, Identifier[][]> roomCountStats = new HashMap<>();
+    private static final Map<Class<? extends StructurePiece>, Identifier[][]> roomTimeStats = new HashMap<>();
+    private static final Map<Class<? extends StructurePiece>, Identifier[][]> averageTimeStats = new HashMap<>();
 
     private static boolean isValid(Class<? extends StructurePiece> pieceType) {
-        return ((!RoomFormatter.ROOM_TO_STRING.get(pieceType).equals("PortalRoom")) && (!RoomFormatter.ROOM_TO_STRING.get(pieceType).equals("None")));
+        return (!RoomFormatter.ROOM_TO_STRING.get(pieceType).equals("None"));
     }
 
     public static void register() {
         for (Class<? extends StructurePiece> pieceType : RoomFormatter.ROOM_TO_STRING.keySet()) {
             if (isValid(pieceType)) {
-                String countName = "piece_" + RoomFormatter.ROOM_TO_STRING.get(pieceType).toLowerCase().replace(" ", "_") + "_count";
-                String timeName = "piece_" + RoomFormatter.ROOM_TO_STRING.get(pieceType).toLowerCase().replace(" ", "_") + "_total";
-                String avgName = "piece_" + RoomFormatter.ROOM_TO_STRING.get(pieceType).toLowerCase().replace(" ", "_") + "_avg";
+                int num_exits = RoomFormatter.ROOM_TO_NUM_EXITS.get(pieceType);
 
-                roomCountStats.put(pieceType, new Identifier(StrongholdTrainerStats.MODID, countName));
-                roomTimeStats.put(pieceType, new Identifier(StrongholdTrainerStats.MODID, timeName));
-                averageTimeStats.put(pieceType, new Identifier(StrongholdTrainerStats.MODID, avgName));
+                // +2 added for entrance and wormholes
+                Identifier[][] pieceRoomCountStats = new Identifier[num_exits+2][num_exits+2];
+                Identifier[][] pieceRoomTimeStats = new Identifier[num_exits+2][num_exits+2];
+                Identifier[][] pieceAverageCountStats = new Identifier[num_exits+2][num_exits+2];
+                
+                // +1 added for wormholes, <= used for entrance
+                for (int entrance = 0; entrance <= num_exits+1; entrance++) {
+                    for (int exit = 0; exit <= num_exits+1; exit++) {
+                        // if > num_exits, converts to "worm" for clarity
+                        String entranceString = doorToString(num_exits, entrance);
+                        String exitString = doorToString(num_exits, exit);
 
-                Registry.register(Registry.CUSTOM_STAT, countName, roomCountStats.get(pieceType));
-                Registry.register(Registry.CUSTOM_STAT, timeName, roomTimeStats.get(pieceType));
-                Registry.register(Registry.CUSTOM_STAT, avgName, averageTimeStats.get(pieceType));
+                        String countName = "piece_" + RoomFormatter.ROOM_TO_STRING.get(pieceType).toLowerCase().replace(" ", "_") + "_" + entranceString + "_" + exitString + "_count";
+                        String timeName = "piece_" + RoomFormatter.ROOM_TO_STRING.get(pieceType).toLowerCase().replace(" ", "_") + "_" + entranceString + "_" + exitString + "_total";
+                        String avgName = "piece_" + RoomFormatter.ROOM_TO_STRING.get(pieceType).toLowerCase().replace(" ", "_") + "_" + entranceString + "_" + exitString + "_avg";
 
-                Stats.CUSTOM.getOrCreateStat(roomCountStats.get(pieceType), StatFormatter.DEFAULT);
-                Stats.CUSTOM.getOrCreateStat(roomTimeStats.get(pieceType), StatFormatter.TIME);
-                Stats.CUSTOM.getOrCreateStat(averageTimeStats.get(pieceType), StatFormatter.TIME);
+                        pieceRoomCountStats[entrance][exit] = new Identifier(StrongholdTrainerStats.MODID, countName);
+                        pieceRoomTimeStats[entrance][exit] = new Identifier(StrongholdTrainerStats.MODID, timeName);
+                        pieceAverageCountStats[entrance][exit] = new Identifier(StrongholdTrainerStats.MODID, avgName);
+
+                        Registry.register(Registry.CUSTOM_STAT, countName, pieceRoomCountStats[entrance][exit]);
+                        Registry.register(Registry.CUSTOM_STAT, timeName, pieceRoomTimeStats[entrance][exit]);
+                        Registry.register(Registry.CUSTOM_STAT, avgName, pieceAverageCountStats[entrance][exit]);
+
+                        Stats.CUSTOM.getOrCreateStat(pieceRoomCountStats[entrance][exit], StatFormatter.DEFAULT);
+                        Stats.CUSTOM.getOrCreateStat(pieceRoomTimeStats[entrance][exit], StatFormatter.TIME);
+                        Stats.CUSTOM.getOrCreateStat(pieceAverageCountStats[entrance][exit], StatFormatter.TIME);
+                    }
+                }
+
+                roomCountStats.put(pieceType, pieceRoomCountStats);
+                roomTimeStats.put(pieceType, pieceRoomTimeStats);
+                averageTimeStats.put(pieceType, pieceAverageCountStats);
             }
         }
     }
 
-    public static void updateRoomStats(ServerPlayerEntity playerEntity, Class<? extends StructurePiece> pieceType, int timeInTicks) {
+    private static String doorToString(int num_exits, int door) {
+        return door > num_exits ? "worm" : Integer.toString(door);
+    }
+
+    public static void updateRoomStats(ServerPlayerEntity playerEntity, Class<? extends StructurePiece> pieceType, int timeInTicks, int entrance, int exit) {
         //because of this increment count should never be 0
         if (isValid(pieceType)) {
-            playerEntity.incrementStat(roomCountStats.get(pieceType));
-            playerEntity.increaseStat(roomTimeStats.get(pieceType), timeInTicks);
-            int count = playerEntity.getStatHandler().getStat(Stats.CUSTOM.getOrCreateStat(roomCountStats.get(pieceType)));
-            int time = playerEntity.getStatHandler().getStat(Stats.CUSTOM.getOrCreateStat(roomTimeStats.get(pieceType)));
+            playerEntity.incrementStat(roomCountStats.get(pieceType)[entrance][exit]);
+            playerEntity.increaseStat(roomTimeStats.get(pieceType)[entrance][exit], timeInTicks);
+            int count = playerEntity.getStatHandler().getStat(Stats.CUSTOM.getOrCreateStat(roomCountStats.get(pieceType)[entrance][exit]));
+            int time = playerEntity.getStatHandler().getStat(Stats.CUSTOM.getOrCreateStat(roomTimeStats.get(pieceType)[entrance][exit]));
             int avg = time / count;
-            playerEntity.resetStat(Stats.CUSTOM.getOrCreateStat(averageTimeStats.get(pieceType)));
-            playerEntity.increaseStat(averageTimeStats.get(pieceType), avg);
+            playerEntity.resetStat(Stats.CUSTOM.getOrCreateStat(averageTimeStats.get(pieceType)[entrance][exit]));
+            playerEntity.increaseStat(averageTimeStats.get(pieceType)[entrance][exit], avg);
         }
     }
 }

--- a/src/main/java/io/github/mjtb49/strongholdtrainer/stats/RoomStats.java
+++ b/src/main/java/io/github/mjtb49/strongholdtrainer/stats/RoomStats.java
@@ -4,9 +4,7 @@ import io.github.mjtb49.strongholdtrainer.util.RoomFormatter;
 import net.minecraft.structure.StructurePiece;
 
 import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.StringJoiner;
+import java.io.BufferedWriter;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -16,7 +14,7 @@ import java.time.format.DateTimeFormatter;
 public class RoomStats {
     private static final DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd_HH-mm-ss");
 
-    private static final Map<Class<? extends StructurePiece>, ArrayList<Integer>[][]> roomTimeStats = new HashMap<>();
+    private static final ArrayList<ArrayList<PlayerPathEntry>> roomTimeStats = new ArrayList<>();
 
     private static Path path;
 
@@ -24,28 +22,8 @@ public class RoomStats {
         return RoomFormatter.ROOM_TO_STRING.get(pieceType);
     }
 
-    private static int pieceToNumExits(Class<? extends StructurePiece> pieceType) {
-        return RoomFormatter.ROOM_TO_NUM_EXITS.get(pieceType);
-    }
-
-    private static boolean isValid(Class<? extends StructurePiece> pieceType) {
-        return (!RoomFormatter.ROOM_TO_STRING.get(pieceType).equals("None"));
-    }
-
-    @SuppressWarnings("unchecked")
     public static void init(Path path) {
-        RoomStats.path = path; 
-        for (Class<? extends StructurePiece> pieceType: RoomFormatter.ROOM_TO_STRING.keySet()) {
-            int numExits = pieceToNumExits(pieceType);
-            // +2 
-            ArrayList<Integer>[][] data = new ArrayList[numExits+2][numExits+2];
-            for (int entrance = 0; entrance <= numExits + 1; entrance++) {
-                for (int exit = 0; exit <= numExits + 1; exit++) {
-                    data[entrance][exit] = new ArrayList<>();
-                }
-            }
-            roomTimeStats.put(pieceType, data);
-        }
+        RoomStats.path = path;
     }
 
     // ChatGPT wrote this function... I'm impressed
@@ -53,33 +31,21 @@ public class RoomStats {
         // Create file to write to
         LocalDateTime timestamp = LocalDateTime.now();
         String filename = timestamp.format(dateFormatter) + ".txt";
-        try (FileWriter writer = new FileWriter(String.valueOf(path.resolve(filename)))) {
+        try (BufferedWriter writer = new BufferedWriter(new FileWriter(String.valueOf(path.resolve(filename))))) {
             // Write to file
-            for (Class<? extends StructurePiece> pieceType : roomTimeStats.keySet()) {
-                if (!isValid(pieceType)) {
-                    continue;
-                }
-                writer.write(pieceToString(pieceType) + " " + pieceToNumExits(pieceType) + "\n");
-                ArrayList<Integer>[][] stats = roomTimeStats.get(pieceType);
-                for (int i = 0; i < stats.length; i++) {
-                    for (int j = 0; j < stats[i].length; j++) {
-                        writer.write(i + " " + j + ": ");
-                        StringJoiner sj = new StringJoiner(", ");
-                        for (int time : stats[i][j]) {
-                            sj.add(Integer.toString(time));
-                        }
-                        writer.write(sj.toString() + "\n");
-                    }
+            for (ArrayList<PlayerPathEntry> path : roomTimeStats) {
+                writer.write(path.size() + "\n");
+                for (PlayerPathEntry entry : path) {
+                    writer.write(pieceToString(entry.piece.getClass()) + " " + entry.entrance + " " + entry.exit + " " + entry.ticks + "\n");
                 }
             }
+            writer.flush();
         } catch (IOException e) {
             e.printStackTrace();
         }
     }
 
-    public static void updateRoomStats(Class<? extends StructurePiece> pieceType, int timeInTicks, int entrance, int exit) {
-        if (isValid(pieceType)) {
-            roomTimeStats.get(pieceType)[entrance][exit].add(timeInTicks);
-        }
+    public static void updateRoomStats(ArrayList<PlayerPathEntry> path) {
+        roomTimeStats.add(path);
     }
 }

--- a/src/main/java/io/github/mjtb49/strongholdtrainer/stats/StrongholdTrainerStats.java
+++ b/src/main/java/io/github/mjtb49/strongholdtrainer/stats/StrongholdTrainerStats.java
@@ -20,8 +20,6 @@ public class StrongholdTrainerStats {
     public static final Identifier MEDIAN_TIME = new Identifier(MODID, "med_time");
 
     public static void register() {
-        RoomStats.register();
-
         Registry.register(Registry.CUSTOM_STAT, "num_strongholds", NUM_STRONGHOLDS);
         Registry.register(Registry.CUSTOM_STAT, "num_reviewed_rooms", NUM_REVIEWED_ROOMS);
         Registry.register(Registry.CUSTOM_STAT, "num_best_rooms", NUM_BEST_ROOMS);

--- a/src/main/java/io/github/mjtb49/strongholdtrainer/util/RoomFormatter.java
+++ b/src/main/java/io/github/mjtb49/strongholdtrainer/util/RoomFormatter.java
@@ -24,6 +24,23 @@ public class RoomFormatter {
         put(null, "None");
     }};
 
+    public static final Map<Class<? extends StructurePiece>, Integer> ROOM_TO_NUM_EXITS = new HashMap<Class<? extends StructurePiece>, Integer>() {{
+        put(StrongholdGenerator.Corridor.class, 3);
+        put(StrongholdGenerator.PrisonHall.class, 1);
+        put(StrongholdGenerator.LeftTurn.class, 1);
+        put(StrongholdGenerator.RightTurn.class, 1);
+        put(StrongholdGenerator.SquareRoom.class, 3);
+        put(StrongholdGenerator.Stairs.class, 1);
+        put(StrongholdGenerator.SpiralStaircase.class, 1);
+        put(StrongholdGenerator.FiveWayCrossing.class, 5);
+        put(StrongholdGenerator.ChestCorridor.class, 1);
+        put(StrongholdGenerator.Library.class, 0);
+        put(StrongholdGenerator.PortalRoom.class, 0);
+        put(StrongholdGenerator.SmallCorridor.class, 0);
+        put(StrongholdGenerator.Start.class, 1);
+        put(null, 0);
+    }};
+
     public static String getStrongholdPieceAsString(Class<? extends StructurePiece> piece) {
         return ROOM_TO_STRING.get(piece);
     }


### PR DESCRIPTION
For my project, I wanted more precise time data so that my models could accurately learn that it is easier to go down a spiral staircase than to go up one, for example. This code also separately keeps track of wormholes, though that is mostly so it does not contaminate any other data. This does massively bloat the player's statistics page, which maybe could be addressed in the future, but it is honestly nice to be able to see the data in-game to know whether there are any things you haven't done yet.