### PR TITLE
Fix crash with SpeedRunIGT

### DIFF
--- a/src/main/java/io/github/mjtb49/strongholdtrainer/mixin/MixinEndPortalBlock.java
+++ b/src/main/java/io/github/mjtb49/strongholdtrainer/mixin/MixinEndPortalBlock.java
@@ -11,15 +11,18 @@ import net.minecraft.util.shape.VoxelShapes;
 import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-@Mixin(EndPortalBlock.class)
+@Mixin(value = EndPortalBlock.class, priority = 100)
 public class MixinEndPortalBlock {
     /**
      * @author fsharpseven
      * @reason custom portal
      */
-    @Overwrite
-    public void onEntityCollision(BlockState state, World world, BlockPos pos, Entity entity) {
+    @Inject(method = "onEntityCollision", at = @At("HEAD"), cancellable = true)
+    public void strongholdtrainer$onEntityCollision(BlockState state, World world, BlockPos pos, Entity entity, CallbackInfo ci) {
         if (world instanceof ServerWorld &&
                 !entity.hasVehicle() &&
                 !entity.hasPassengers() &&
@@ -31,5 +34,6 @@ public class MixinEndPortalBlock {
             }
             world.getServer().getCommandManager().execute(entity.getCommandSource(), "newStronghold");
         }
+        ci.cancel();
     }
 }


### PR DESCRIPTION
I know this project is over 2 years old. But still some people are using it, so this pr is solves crashes with SpeedRunIGT cause by `EndPortalBlock` mixin method overwrite.